### PR TITLE
Improve MariaDB 10.11 compatibility and Rocky Linux 9 build support

### DIFF
--- a/AuthServer.cpp
+++ b/AuthServer.cpp
@@ -35,7 +35,7 @@ bool AuthServer::bruteForceManager(QString ip)
     } else {
         challenges.insert(ip, 1);
     }
-    if (challenges[ip] > Settings::antibrut_count && !blocked.contains(ip)) {
+    if (challenges[ip] > static_cast<uint>(Settings::antibrut_count) && !blocked.contains(ip)) {
         blocked.insert(ip, QDateTime::currentDateTime().toTime_t());
         Utils::print(QString("Ip: %1 has been blocked").arg(ip));
         return true;

--- a/Database.cpp
+++ b/Database.cpp
@@ -1,16 +1,25 @@
 #include "Database.h"
+#include <QStringList>
 
 Database* Database::self = NULL;
 
 void Database::connect()
 {
+    if (!QSqlDatabase::isDriverAvailable("QMYSQL")) {
+        Utils::print("QMYSQL driver is not available. Install the MySQL/MariaDB Qt driver (qt5-qtbase-mysql) before starting the daemon.");
+        exit(1);
+    }
+
     db = QSqlDatabase::addDatabase("QMYSQL");
     db.setHostName(Settings::mysql_host);
     db.setPort(Settings::mysql_port);
     db.setUserName(Settings::mysql_user);
     db.setPassword(Settings::mysql_pass);
     db.setDatabaseName(Settings::mysql_db);
-    db.setConnectOptions("MYSQL_OPT_RECONNECT=1;MYSQL_OPT_CONNECT_TIMEOUT=300");
+    QStringList options;
+    options << "MYSQL_OPT_RECONNECT=1"
+            << "MYSQL_OPT_CONNECT_TIMEOUT=300";
+    db.setConnectOptions(options.join(";"));
     if (!db.open()) {
         Utils::print(QString("Cant connect to mysql: %1").arg(db.lastError().text()));
         exit(0);

--- a/Protocol/UserLogin.cpp
+++ b/Protocol/UserLogin.cpp
@@ -15,14 +15,15 @@ void UserLogin::Unmarshal()
     Database *db = Database::Instance();
     AuthServer *server = AuthServer::Instance();
     int zoneid = server->Zoneid;
-    int zonelocalsid = localsid;
+    const int localsidInt = static_cast<int>(localsid);
+    int zonelocalsid = localsidInt;
     int overwrite = blkickuser;
     db->recordOnline(userid, AuthServer::Instance()->Aid, zoneid, zonelocalsid, overwrite);
     int creatime;
     db->acquireUserCreatime(userid, creatime);
     Reset();
     writeUInt32(calcSession());
-    if (server->Zoneid != zoneid || zonelocalsid != localsid)
+    if (server->Zoneid != zoneid || zonelocalsid != localsidInt)
     {
         writeByte(10);
     }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ For Fedora-based distributions you can run the provided `install.sh` to install 
 #### Rocky Linux 9
 
 ```bash
-sudo dnf install qt5-qtbase-devel qt5-qtbase qt5-qttools qt5-qttools-devel qt5-qtbase-mysql mariadb-server mariadb-devel gcc-c++
+sudo dnf install qt5-qtbase-devel qt5-qtbase qt5-qttools qt5-qttools-devel qt5-qtbase-mysql mariadb-server mariadb-devel mariadb-connector-c mariadb-connector-c-devel gcc-c++
 ```
+
+For MariaDB 10.11, enable the official MariaDB repository that matches your Rocky Linux release and install the `MariaDB-server` and `MariaDB-client` packages from that repository before building. The daemon links against the system-provided MariaDB connector, so keeping the connector packages in sync with the server version prevents runtime driver errors.
 
 #### Ubuntu 20.04
 

--- a/gauthd.pro
+++ b/gauthd.pro
@@ -46,9 +46,16 @@ HEADERS += \
 
 QMAKE_LFLAGS += 
 
-CONFIG(32bit) {
-    LIBS += -L$$PWD/../../../../opt/Qt/mysql/x32/lib/libmysqlclient.a
-}
-CONFIG(64bit) {
-    LIBS += -L$$PWD/../../../../opt/Qt/mysql/x64/lib/libmysqlclient.a
+unix:!macx {
+    mariadb_pkg = $$system("pkg-config --exists mariadb && echo 1")
+    mysqlclient_pkg = $$system("pkg-config --exists mysqlclient && echo 1")
+    !isEmpty(mariadb_pkg) {
+        CONFIG += link_pkgconfig
+        PKGCONFIG += mariadb
+    } else:!isEmpty(mysqlclient_pkg) {
+        CONFIG += link_pkgconfig
+        PKGCONFIG += mysqlclient
+    } else {
+        LIBS += -lmariadb -lmysqlclient
+    }
 }

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,14 @@ if ! sudo dnf install -y qt5-qtbase-devel qt5-qtx11extras qt5-qttools | tee -a $
     exit 1
 fi
 
+# Install MariaDB client and server packages to match Rocky 9/MariaDB 10.11 builds
+log "Installing MariaDB packages and Qt MySQL driver..."
+echo "Installing MariaDB packages and Qt MySQL driver..."
+if ! sudo dnf install -y qt5-qtbase-mysql mariadb-server mariadb-devel mariadb-connector-c mariadb-connector-c-devel | tee -a $LOGFILE; then
+    log "Error installing MariaDB packages."
+    exit 1
+fi
+
 # Remove unnecessary packages and display progress in the terminal and in the log
 log "Removing unnecessary packages..."
 echo "Removing unnecessary packages..."


### PR DESCRIPTION
## Summary
- guard startup when the QMYSQL driver is missing and enable recognized MySQL connect options for MariaDB 10.11
- rely on system-provided MariaDB/MySQL client libraries via pkg-config instead of hard-coded static paths
- document Rocky Linux 9/MariaDB 10.11 package requirements, update the installer to pull matching connector packages, and resolve signed/unsigned warnings in auth and login flows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abcd244548333af54e4066ce8f199)